### PR TITLE
[Fixes #9] Increase multidevice response

### DIFF
--- a/encryption/encryption_test.go
+++ b/encryption/encryption_test.go
@@ -88,7 +88,8 @@ func (s *EncryptionServiceTestSuite) TestGetBundle() {
 
 	aliceBundle2, err := s.alice.GetBundle(aliceKey)
 	s.Require().NoError(err)
-	s.Equal(aliceBundle1, aliceBundle2, "It returns the same bundle")
+	s.Equal(aliceBundle1.GetSignedPreKeys(), aliceBundle2.GetSignedPreKeys(), "It returns the same signed pre keys")
+	s.NotEqual(aliceBundle1.Timestamp, aliceBundle2.Timestamp, "It refreshes the timestamp")
 }
 
 // Alice sends Bob an encrypted message with DH using an ephemeral key

--- a/encryption/x3dh.go
+++ b/encryption/x3dh.go
@@ -44,7 +44,9 @@ func buildSignatureMaterial(bundle *Bundle) []byte {
 
 }
 
+// SignBundle signs the bundle and refreshes the timestamps
 func SignBundle(identity *ecdsa.PrivateKey, bundleContainer *BundleContainer) error {
+	bundleContainer.Bundle.Timestamp = time.Now().UnixNano()
 	signatureMaterial := buildSignatureMaterial(bundleContainer.GetBundle())
 
 	signature, err := crypto.Sign(crypto.Keccak256(signatureMaterial), identity)

--- a/messenger_test.go
+++ b/messenger_test.go
@@ -81,7 +81,7 @@ func (s *MessengerSuite) SetupTest() {
 	config := whisper.DefaultConfig
 	config.MinimumAcceptedPOW = 0
 	shh := whisper.New(&config)
-	shh.Start(nil)
+	s.Require().NoError(shh.Start(nil))
 
 	s.m, err = NewMessenger(
 		s.privateKey,


### PR DESCRIPTION
We only generate the bundle once every 6 hours (or if pairing
information changes).
This means that in some cases where many devices appear/disappear,
new devices are not picked up until the bundle is refreshed.

For example:

Alice creates a device with timestamp t1 A1
Alice creates a device with timestamp t2 A2
Alice creates a device with timestamp t3 A3
Alice creates a device with timestamp t4 A4

Alice propagates this to bob, bob's list of active devices for alice is now: t2 A2,
t3 A3, t4 A4 as we only keep maximum 3.

If Alice sends a message to Bob from A1, previously it would be still
using t1 (as long as less than 6 hours have passed).

Now instead the new bundle will have t5 instead, so upon receiving the
message bob will have: t3 A3, t4 A4, t5 A1.

This commit changes the behavior to always update the timestamp before
publishing the bundle, so that as soon as a message is received from a
new device, it will increase the timestamp for that device.

Please don't merge until successfully tested.

### Testing
1) Create device B1
2) Create device A1, enabled device-to-device, send a message to B
2) Create device A2,  enabled device-to-device, send a message to B
3) Create device A3,  enabled device-to-device, send a message to B
4) Create device A4,  enabled device-to-device, send a message to B
5) Send a message from B1 to A
6) A2, A3, A4 should receive the message
7) Send a message from A1 to B
8) Send a message from B1 to A

In develop A2, A3, A4 should receive the message
In this pr A1, A3, A4 should receive the message