### PR TITLE
Add option to enable legacy generic discovery topic support

### DIFF
--- a/transport/whisper/whisper_service.go
+++ b/transport/whisper/whisper_service.go
@@ -129,8 +129,9 @@ func (a *WhisperServiceTransport) Init(
 	chatIDs []string,
 	publicKeys []*ecdsa.PublicKey,
 	negotiated []filter.NegotiatedSecret,
+	genericDiscoveryTopicEnabled bool,
 ) ([]*filter.Chat, error) {
-	return a.chats.Init(chatIDs, publicKeys, negotiated)
+	return a.chats.Init(chatIDs, publicKeys, negotiated, genericDiscoveryTopicEnabled)
 }
 
 func (a *WhisperServiceTransport) ProcessNegotiatedSecret(secret filter.NegotiatedSecret) error {

--- a/v1/constants.go
+++ b/v1/constants.go
@@ -1,9 +1,0 @@
-package statusproto
-
-const (
-	TopicDiscovery = "contact-discovery"
-)
-
-func DefaultPrivateTopic() string {
-	return TopicDiscovery
-}


### PR DESCRIPTION
This PR adds an option to enable legacy generic discovery topic support (disabled by default).

Closes #12 

Notes:
- I noticed that we're not testing e.g. which arguments `WhisperServiceTransport.Init` calls `ChatManager.Init` with. Not sure if that's something we want to do (e.g. with mocks).
- Same thing for `Messenger` and `newWhisperAdapter` (although here we could perhaps test the end result, i.e. that `transport.SendPrivateWithPartitioned` is called when `Messenger` is created with the option disabled).