### PR TITLE
Propagate shared secrets on init

### DIFF
--- a/messenger.go
+++ b/messenger.go
@@ -150,8 +150,6 @@ func NewMessenger(
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create the encryption layer")
 	}
-	// TODO: consider removing identity as an argument to Start().
-	encryptionProtocol.Start(identity)
 
 	messagesDB, err := sqlite.Open(filepath.Join(dataDir, "messages.sql"), dbKey, sqlite.MigrationConfig{
 		AssetNames: migrations.AssetNames(),
@@ -169,6 +167,12 @@ func NewMessenger(
 		adapter:     newWhisperAdapter(identity, t, encryptionProtocol),
 		encryptor:   encryptionProtocol,
 		ownMessages: make(map[string][]*protocol.Message),
+	}
+
+	// Start all services immediately.
+	// TODO: consider removing identity as an argument to Start().
+	if err := encryptionProtocol.Start(identity); err != nil {
+		return nil, err
 	}
 
 	return messenger, nil

--- a/messenger_test.go
+++ b/messenger_test.go
@@ -13,28 +13,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/crypto"
 	whisper "github.com/status-im/whisper/whisperv6"
-	"github.com/stretchr/testify/require"
 )
-
-func TestNewMessenger(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "messenger-test")
-	require.NoError(t, err)
-	privateKey, err := crypto.GenerateKey()
-	require.NoError(t, err)
-
-	shh := whisper.New(nil)
-
-	_, err = NewMessenger(
-		privateKey,
-		nil,
-		shh,
-		tmpDir,
-		"some-key",
-		"installation-1",
-		WithChats([]string{"status"}, nil, nil),
-	)
-	require.NoError(t, err)
-}
 
 type testChat struct {
 	publicName string

--- a/transport/whisper/filter/chats.go
+++ b/transport/whisper/filter/chats.go
@@ -61,7 +61,7 @@ type ChatsManager struct {
 	whisper     *whisper.Whisper
 	persistence *sqlitePersistence
 	privateKey  *ecdsa.PrivateKey
-	keys        map[string][]byte
+	keys        map[string][]byte // a cache of symmetric keys derived from passwords
 
 	mutex sync.Mutex
 	chats map[string]*Chat
@@ -109,7 +109,7 @@ func (s *ChatsManager) Init(chatIDs []string, publicKeys []*ecdsa.PublicKey, neg
 		return nil, err
 	}
 
-	// Add public, one-to-one and generic chats.
+	// Add public, one-to-one and negotiated chats.
 	for _, chatID := range chatIDs {
 		_, err := s.LoadPublic(chatID)
 		if err != nil {


### PR DESCRIPTION
As we moved shared secrets into the library, they won't be passed from the caller anymore. After initialization and encryption protocol start, they should be retrieved from the database and propagated to create proper filters, otherwise, we won't receive messages sent using the shared (negotiated) secret.