### PR TITLE
define a JSON hex encoder which encodes bytes in hex instead of base64

### DIFF
--- a/log_encoder.go
+++ b/log_encoder.go
@@ -1,0 +1,29 @@
+package statusproto
+
+import (
+	"encoding/hex"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type jsonHexEncoder struct {
+	zapcore.Encoder
+}
+
+func NewJSONHexEncoder(cfg zapcore.EncoderConfig) zapcore.Encoder {
+	jsonEncoder := zapcore.NewJSONEncoder(cfg)
+	return &jsonHexEncoder{
+		Encoder: jsonEncoder,
+	}
+}
+
+func (enc *jsonHexEncoder) AddBinary(key string, val []byte) {
+	enc.AddString(key, "0x"+hex.EncodeToString(val))
+}
+
+func registerJSONHexEncoder() error {
+	return zap.RegisterEncoder("json-hex", func(cfg zapcore.EncoderConfig) (zapcore.Encoder, error) {
+		return NewJSONHexEncoder(cfg), nil
+	})
+}

--- a/log_encoder.go
+++ b/log_encoder.go
@@ -11,6 +11,10 @@ type jsonHexEncoder struct {
 	zapcore.Encoder
 }
 
+// NewJSONHexEncoder creates a JSON logger based on zapcore.NewJSONEncoder
+// but overwrites encoding of byte slices. Instead encoding them with base64,
+// jsonHexEncoder uses hex-encoding.
+// Each hex-encoded value is prefixed with 0x so that it's clear it's a hex string.
 func NewJSONHexEncoder(cfg zapcore.EncoderConfig) zapcore.Encoder {
 	jsonEncoder := zapcore.NewJSONEncoder(cfg)
 	return &jsonHexEncoder{
@@ -22,7 +26,10 @@ func (enc *jsonHexEncoder) AddBinary(key string, val []byte) {
 	enc.AddString(key, "0x"+hex.EncodeToString(val))
 }
 
-func registerJSONHexEncoder() error {
+// RegisterJSONHexEncoder registers a jsonHexEncoder under "json-hex" name.
+// Later, this name can be used as a value for zap.Config.Encoding to enable
+// jsonHexEncoder.
+func RegisterJSONHexEncoder() error {
 	return zap.RegisterEncoder("json-hex", func(cfg zapcore.EncoderConfig) (zapcore.Encoder, error) {
 		return NewJSONHexEncoder(cfg), nil
 	})

--- a/log_encoder_test.go
+++ b/log_encoder_test.go
@@ -1,0 +1,23 @@
+package statusproto
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestJSONHexEncoder(t *testing.T) {
+	encoder := NewJSONHexEncoder(zap.NewDevelopmentEncoderConfig())
+	encoder.AddBinary("test-key", []byte{0x01, 0x02, 0x03})
+	buf, err := encoder.EncodeEntry(zapcore.Entry{
+		LoggerName: "",
+		Time:       time.Now(),
+		Level:      zapcore.DebugLevel,
+		Message:    "",
+	}, nil)
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), `"test-key":"0x010203"`)
+}


### PR DESCRIPTION
As a developer
I would like the logger to have byte slices encoded as hex instead of base64
as hex encoding is usually used by us.