### PR TITLE
Don't return errors on logger.Sync

### DIFF
--- a/messenger.go
+++ b/messenger.go
@@ -248,7 +248,9 @@ func NewMessenger(
 		shutdownTasks: []func() error{
 			persistence.Close,
 			adapter.transport.Reset,
-			logger.Sync,
+			// Currently this often fails, seems like it's safe to ignore them
+			// https://github.com/uber-go/zap/issues/328
+			func() error { _ = logger.Sync; return nil },
 		},
 		logger: logger,
 	}


### PR DESCRIPTION
Currently logger.Sync fails often (or always), reading https://github.com/uber-go/zap/issues/328
seems like it's safe to ignore.

This is causing problem with https://github.com/status-im/status-react/pull/8615 , as it interrupts the stoping of the node, as some resources are not cleaned up properly.

Seems like this does not get called https://github.com/status-im/status-go/blob/19c26b129dc0a81caa10923fb3b8b36e2da05535/node/status_node.go#L364 so next time we start the node it will fail.

I don't think that's the correct behavior of `status-go`, it should be cleaning up all the resources regardless, especially if they belong to different services, but this at least will solve our immediate problem and we can later address the issue in status-go.