### PR TITLE
Use wrapped payload for id calculation

### DIFF
--- a/adapters_test.go
+++ b/adapters_test.go
@@ -215,7 +215,7 @@ func (s *AdaptersSuite) TestHandleDecodedMessagesWrapped() {
 
 	s.Require().Equal(1, len(decodedMessages))
 	s.Require().Equal(&authorKey.PublicKey, decodedMessages[0].SigPubKey())
-	s.Require().Equal(protocol.MessageID(&authorKey.PublicKey, encodedPayload), decodedMessages[0].ID)
+	s.Require().Equal(protocol.MessageID(&authorKey.PublicKey, wrappedPayload), decodedMessages[0].ID)
 	s.Require().Equal(encodedPayload, decodedMessages[0].DecryptedPayload)
 	s.Require().Equal(testMessageStruct, decodedMessages[0].ParsedMessage)
 }
@@ -257,7 +257,7 @@ func (s *AdaptersSuite) TestHandleDecodedMessagesDatasync() {
 	s.Require().Equal(testMessageStruct, decodedMessages[0].ParsedMessage)
 
 	s.Require().Equal(&authorKey.PublicKey, decodedMessages[1].SigPubKey())
-	s.Require().Equal(protocol.MessageID(&authorKey.PublicKey, encodedPayload), decodedMessages[1].ID)
+	s.Require().Equal(protocol.MessageID(&authorKey.PublicKey, wrappedPayload), decodedMessages[1].ID)
 	s.Require().Equal(encodedPayload, decodedMessages[1].DecryptedPayload)
 	s.Require().Equal(testMessageStruct, decodedMessages[1].ParsedMessage)
 }
@@ -305,7 +305,7 @@ func (s *AdaptersSuite) TestHandleDecodedMessagesDatasyncEncrypted() {
 	s.Require().Equal(testMessageStruct, decodedMessages[0].ParsedMessage)
 
 	s.Require().Equal(&authorKey.PublicKey, decodedMessages[1].SigPubKey())
-	s.Require().Equal(protocol.MessageID(&authorKey.PublicKey, encodedPayload), decodedMessages[1].ID)
+	s.Require().Equal(protocol.MessageID(&authorKey.PublicKey, wrappedPayload), decodedMessages[1].ID)
 	s.Require().Equal(encodedPayload, decodedMessages[1].DecryptedPayload)
 	s.Require().Equal(testMessageStruct, decodedMessages[1].ParsedMessage)
 }

--- a/v1/status_message.go
+++ b/v1/status_message.go
@@ -125,8 +125,9 @@ func (m *StatusMessage) HandleApplicationMetadata() error {
 		return err
 	}
 	m.ApplicationMetadataLayerSigPubKey = recoveredKey
+	// Calculate ID using the wrapped record
+	m.ID = MessageID(recoveredKey, m.DecryptedPayload)
 	m.DecryptedPayload = message.Payload
-	m.ID = MessageID(m.SigPubKey(), m.DecryptedPayload)
 	return nil
 
 }


### PR DESCRIPTION
Now that status-react is not calculating ids anymore (only status-protocol-go does), we can use the wrapped payload for id calculation also when receiving.