### PR TITLE
add Messenger.Init()

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -1,6 +1,11 @@
 package statusproto
 
-import "crypto/ecdsa"
+import (
+	"crypto/ecdsa"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+)
 
 type ChatPagination struct {
 	From uint
@@ -78,4 +83,12 @@ type ChatMember struct {
 	Admin bool `json:"admin"`
 	// Joined indicates if the member has joined the group chat
 	Joined bool `json:"joined"`
+}
+
+func (c ChatMember) PublicKey() (*ecdsa.PublicKey, error) {
+	b, err := hexutil.Decode(c.ID)
+	if err != nil {
+		return nil, err
+	}
+	return crypto.UnmarshalPubkey(b)
 }

--- a/contact.go
+++ b/contact.go
@@ -1,5 +1,18 @@
 package statusproto
 
+import (
+	"crypto/ecdsa"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+const (
+	contactBlocked         = "contact/blocked"
+	contactAdded           = "contact/added"
+	contactRequestReceived = "contact/request-received"
+)
+
 // ContactDeviceInfo is a struct containing information about a particular device owned by a contact
 type ContactDeviceInfo struct {
 	// The installation id of the device
@@ -13,7 +26,7 @@ type ContactDeviceInfo struct {
 // Contact has information about a "Contact". A contact is not necessarily one
 // that we added or added us, that's based on SystemTags.
 type Contact struct {
-	// ID of the contact
+	// ID of the contact. It's a hex-encoded public key (prefixed with 0x).
 	ID string `json:"id"`
 	// Ethereum address of the contact
 	Address string `json:"address"`
@@ -30,4 +43,34 @@ type Contact struct {
 
 	DeviceInfo    []ContactDeviceInfo `json:"deviceInfo"`
 	TributeToTalk string              `json:"tributeToTalk"`
+}
+
+func (c Contact) PublicKey() (*ecdsa.PublicKey, error) {
+	b, err := hexutil.Decode(c.ID)
+	if err != nil {
+		return nil, err
+	}
+	return crypto.UnmarshalPubkey(b)
+}
+
+func (c Contact) IsAdded() bool {
+	return existsInStringSlice(c.SystemTags, contactAdded)
+}
+
+func (c Contact) HasBeenAdded() bool {
+	return existsInStringSlice(c.SystemTags, contactRequestReceived)
+}
+
+func (c Contact) IsBlocked() bool {
+	return existsInStringSlice(c.SystemTags, contactBlocked)
+}
+
+// exists checks if a string is in a set.
+func existsInStringSlice(set []string, find string) bool {
+	for _, s := range set {
+		if s == find {
+			return true
+		}
+	}
+	return false
 }

--- a/contact.go
+++ b/contact.go
@@ -65,7 +65,7 @@ func (c Contact) IsBlocked() bool {
 	return existsInStringSlice(c.SystemTags, contactBlocked)
 }
 
-// exists checks if a string is in a set.
+// existsInStringSlice checks if a string is in a set.
 func existsInStringSlice(set []string, find string) bool {
 	for _, s := range set {
 		if s == find {

--- a/messenger.go
+++ b/messenger.go
@@ -338,10 +338,21 @@ func (m *Messenger) Init() error {
 		if !chat.Active {
 			continue
 		}
-		if chat.ChatType == ChatTypePublic {
+		switch chat.ChatType {
+		case ChatTypePublic:
 			publicChatIDs = append(publicChatIDs, chat.ID)
-		} else if chat.ChatType == ChatTypeOneToOne {
+		case ChatTypeOneToOne:
 			publicKeys = append(publicKeys, chat.PublicKey)
+		case ChatTypePrivateGroupChat:
+			for _, member := range chat.Members {
+				publicKey, err := member.PublicKey()
+				if err != nil {
+					return errors.Wrapf(err, "invalid public key for member %s in chat %s", member.ID, chat.Name)
+				}
+				publicKeys = append(publicKeys, publicKey)
+			}
+		default:
+			return errors.New("invalid chat type")
 		}
 	}
 

--- a/messenger.go
+++ b/messenger.go
@@ -251,6 +251,7 @@ func NewMessenger(
 		nil,
 		c.envelopesMonitorConfig,
 		logger,
+		transport.SetGenericDiscoveryTopicSupport(c.featureFlags.genericDiscoveryTopicEnabled),
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create a WhisperServiceTransport")
@@ -315,6 +316,55 @@ func NewMessenger(
 	logger.Debug("messages persistence", zap.Bool("enabled", c.messagesPersistenceEnabled))
 
 	return messenger, nil
+}
+
+// Init analyzes chats and contacts in order to setup filters
+// which are responsible for retrieving messages.
+func (m *Messenger) Init() error {
+	logger := m.logger.With(zap.String("site", "Init"))
+
+	var (
+		publicChatIDs []string
+		publicKeys    []*ecdsa.PublicKey
+	)
+
+	// Get chat IDs and public keys from the existing chats.
+	// TODO: Get only active chats by the query.
+	chats, err := m.Chats()
+	if err != nil {
+		return err
+	}
+	for _, chat := range chats {
+		if !chat.Active {
+			continue
+		}
+		if chat.ChatType == ChatTypePublic {
+			publicChatIDs = append(publicChatIDs, chat.ID)
+		} else if chat.ChatType == ChatTypeOneToOne {
+			publicKeys = append(publicKeys, chat.PublicKey)
+		}
+	}
+
+	// Get chat IDs and public keys from the contacts.
+	contacts, err := m.Contacts()
+	if err != nil {
+		return err
+	}
+	for _, contact := range contacts {
+		// We only need filters for contacts added by us and not blocked.
+		if !contact.IsAdded() || contact.IsBlocked() {
+			continue
+		}
+		publicKey, err := contact.PublicKey()
+		if err != nil {
+			logger.Error("failed to get contact's public key", zap.Error(err))
+			continue
+		}
+		publicKeys = append(publicKeys, publicKey)
+	}
+
+	_, err = m.adapter.transport.InitFilters(publicChatIDs, publicKeys)
+	return err
 }
 
 // Shutdown takes care of ensuring a clean shutdown of Messenger
@@ -396,8 +446,8 @@ func (m *Messenger) SaveChat(chat Chat) error {
 	return m.persistence.SaveChat(chat)
 }
 
-func (m *Messenger) Chats(from, to int) ([]*Chat, error) {
-	return m.persistence.Chats(from, to)
+func (m *Messenger) Chats() ([]*Chat, error) {
+	return m.persistence.Chats()
 }
 
 func (m *Messenger) DeleteChat(chatID string) error {
@@ -594,13 +644,13 @@ func (m *Messenger) RetrieveRawAll() (map[transport.Filter][]*protocol.StatusMes
 }
 
 // DEPRECATED
-func (m *Messenger) LoadFilters(chats []*transport.Filter) ([]*transport.Filter, error) {
-	return m.adapter.transport.LoadFilters(chats, m.featureFlags.genericDiscoveryTopicEnabled)
+func (m *Messenger) LoadFilters(filters []*transport.Filter) ([]*transport.Filter, error) {
+	return m.adapter.transport.LoadFilters(filters)
 }
 
 // DEPRECATED
-func (m *Messenger) RemoveFilters(chats []*transport.Filter) error {
-	return m.adapter.transport.RemoveFilters(chats)
+func (m *Messenger) RemoveFilters(filters []*transport.Filter) error {
+	return m.adapter.transport.RemoveFilters(filters)
 }
 
 // DEPRECATED

--- a/messenger_test.go
+++ b/messenger_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/hex"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -145,7 +144,7 @@ func (s *MessengerSuite) TestChatPersistencePublic() {
 	}
 
 	s.Require().NoError(s.m.SaveChat(chat))
-	savedChats, err := s.m.Chats(0, 10)
+	savedChats, err := s.m.Chats()
 	s.Require().NoError(err)
 	s.Require().Equal(1, len(savedChats))
 
@@ -172,12 +171,12 @@ func (s *MessengerSuite) TestDeleteChat() {
 	}
 
 	s.Require().NoError(s.m.SaveChat(chat))
-	savedChats, err := s.m.Chats(0, 10)
+	savedChats, err := s.m.Chats()
 	s.Require().NoError(err)
 	s.Require().Equal(1, len(savedChats))
 
 	s.Require().NoError(s.m.DeleteChat(chatID))
-	savedChats, err = s.m.Chats(0, 10)
+	savedChats, err = s.m.Chats()
 	s.Require().NoError(err)
 	s.Require().Equal(0, len(savedChats))
 }
@@ -198,7 +197,7 @@ func (s *MessengerSuite) TestChatPersistenceUpdate() {
 	}
 
 	s.Require().NoError(s.m.SaveChat(chat))
-	savedChats, err := s.m.Chats(0, 10)
+	savedChats, err := s.m.Chats()
 	s.Require().NoError(err)
 	s.Require().Equal(1, len(savedChats))
 
@@ -209,7 +208,7 @@ func (s *MessengerSuite) TestChatPersistenceUpdate() {
 
 	chat.Name = "updated-name"
 	s.Require().NoError(s.m.SaveChat(chat))
-	updatedChats, err := s.m.Chats(0, 10)
+	updatedChats, err := s.m.Chats()
 	s.Require().NoError(err)
 	s.Require().Equal(1, len(updatedChats))
 
@@ -217,37 +216,6 @@ func (s *MessengerSuite) TestChatPersistenceUpdate() {
 	expectedUpdatedChat := &chat
 
 	s.Require().Equal(expectedUpdatedChat, actualUpdatedChat)
-}
-
-func (s *MessengerSuite) TestChatPagination() {
-	for i := 0; i <= 20; i++ {
-		chat := Chat{
-			ID:                     fmt.Sprintf("chat-name-%d", i),
-			Name:                   "chat-name",
-			Color:                  "#fffff",
-			Active:                 true,
-			ChatType:               ChatTypePublic,
-			Timestamp:              int64(i),
-			LastClockValue:         20,
-			DeletedAtClockValue:    30,
-			UnviewedMessagesCount:  40,
-			LastMessageContentType: "something",
-			LastMessageContent:     "something-else",
-		}
-
-		s.Require().NoError(s.m.SaveChat(chat))
-	}
-	firstPageChats, err := s.m.Chats(0, 10)
-	s.Require().NoError(err)
-	s.Require().Equal(10, len(firstPageChats))
-	s.Require().Equal(int64(20), firstPageChats[0].Timestamp)
-	s.Require().Equal(int64(11), firstPageChats[9].Timestamp)
-
-	secondPageChats, err := s.m.Chats(10, -1)
-	s.Require().NoError(err)
-	s.Require().Equal(11, len(secondPageChats))
-	s.Require().Equal(int64(10), secondPageChats[0].Timestamp)
-	s.Require().Equal(int64(0), secondPageChats[10].Timestamp)
 }
 
 func (s *MessengerSuite) TestChatPersistenceOneToOne() {
@@ -272,7 +240,7 @@ func (s *MessengerSuite) TestChatPersistenceOneToOne() {
 	s.Require().NoError(err)
 
 	s.Require().NoError(s.m.SaveChat(chat))
-	savedChats, err := s.m.Chats(0, 10)
+	savedChats, err := s.m.Chats()
 	s.Require().NoError(err)
 	s.Require().Equal(1, len(savedChats))
 
@@ -337,7 +305,7 @@ func (s *MessengerSuite) TestChatPersistencePrivateGroupChat() {
 		LastMessageContent:     "something-else",
 	}
 	s.Require().NoError(s.m.SaveChat(chat))
-	savedChats, err := s.m.Chats(0, 10)
+	savedChats, err := s.m.Chats()
 	s.Require().NoError(err)
 	s.Require().Equal(1, len(savedChats))
 
@@ -506,7 +474,7 @@ func (s *MessengerSuite) TestBlockContact() {
 	s.Require().Equal("blocked", savedContacts[0].Name)
 
 	// The chat is deleted
-	actualChats, err := s.m.Chats(0, -1)
+	actualChats, err := s.m.Chats()
 	s.Require().NoError(err)
 	s.Require().Equal(2, len(actualChats))
 

--- a/persistence.go
+++ b/persistence.go
@@ -113,11 +113,11 @@ func (db sqlitePersistence) DeleteChat(chatID string) error {
 	return err
 }
 
-func (db sqlitePersistence) Chats(from, to int) ([]*Chat, error) {
-	return db.chats(from, to, nil)
+func (db sqlitePersistence) Chats() ([]*Chat, error) {
+	return db.chats(nil)
 }
 
-func (db sqlitePersistence) chats(from, to int, tx *sql.Tx) ([]*Chat, error) {
+func (db sqlitePersistence) chats(tx *sql.Tx) ([]*Chat, error) {
 	var err error
 
 	if tx == nil {
@@ -137,22 +137,22 @@ func (db sqlitePersistence) chats(from, to int, tx *sql.Tx) ([]*Chat, error) {
 	}
 
 	rows, err := tx.Query(`SELECT
-	id,
-	name,
-	color,
-	active,
-	type,
-	timestamp,
-	deleted_at_clock_value,
-	public_key,
-	unviewed_message_count,
-	last_clock_value,
-	last_message_content_type,
-	last_message_content,
-	members,
-	membership_updates
+		id,
+		name,
+		color,
+		active,
+		type,
+		timestamp,
+		deleted_at_clock_value,
+		public_key,
+		unviewed_message_count,
+		last_clock_value,
+		last_message_content_type,
+		last_message_content,
+		members,
+		membership_updates
 	FROM chats
-	ORDER BY chats.timestamp DESC LIMIT ? OFFSET ?`, to, from)
+	ORDER BY chats.timestamp DESC`)
 	if err != nil {
 		return nil, err
 	}

--- a/persistence_legacy.go
+++ b/persistence_legacy.go
@@ -377,5 +377,5 @@ func (db sqlitePersistence) BlockContact(contact Contact) ([]*Chat, error) {
 	}
 
 	// return the updated chats
-	return db.chats(0, -1, tx)
+	return db.chats(tx)
 }

--- a/transport/whisper/whisper_service.go
+++ b/transport/whisper/whisper_service.go
@@ -104,7 +104,6 @@ func NewWhisperServiceTransport(
 		shh:              shh,
 		shhAPI:           whisper.NewPublicWhisperAPI(shh),
 		envelopesMonitor: envelopesMonitor,
-
 		keysManager: &whisperServiceKeysManager{
 			shh:               shh,
 			privateKey:        privateKey,
@@ -126,6 +125,10 @@ func NewWhisperServiceTransport(
 
 func (a *WhisperServiceTransport) InitFilters(chatIDs []string, publicKeys []*ecdsa.PublicKey) ([]*Filter, error) {
 	return a.filters.Init(chatIDs, publicKeys, a.genericDiscoveryTopicEnabled)
+}
+
+func (a *WhisperServiceTransport) Filters() []*Filter {
+	return a.filters.Filters()
 }
 
 // DEPRECATED

--- a/transport/whisper/whisper_service.go
+++ b/transport/whisper/whisper_service.go
@@ -56,16 +56,27 @@ func (m *whisperServiceKeysManager) RawSymKey(id string) ([]byte, error) {
 	return m.shh.GetSymKey(id)
 }
 
+type Option func(*WhisperServiceTransport) error
+
+func SetGenericDiscoveryTopicSupport(val bool) Option {
+	return func(t *WhisperServiceTransport) error {
+		t.genericDiscoveryTopicEnabled = val
+		return nil
+	}
+}
+
 // WhisperServiceTransport is a transport based on Whisper service.
 type WhisperServiceTransport struct {
 	shh         *whisper.Whisper
 	shhAPI      *whisper.PublicWhisperAPI // only PublicWhisperAPI implements logic to send messages
 	keysManager *whisperServiceKeysManager
-	chats       *filtersManager
+	filters     *filtersManager
 	logger      *zap.Logger
 
 	mailservers      []string
 	envelopesMonitor *EnvelopesMonitor
+
+	genericDiscoveryTopicEnabled bool
 }
 
 // NewWhisperService returns a new WhisperServiceTransport.
@@ -76,8 +87,9 @@ func NewWhisperServiceTransport(
 	mailservers []string,
 	envelopesMonitorConfig *EnvelopesMonitorConfig,
 	logger *zap.Logger,
+	opts ...Option,
 ) (*WhisperServiceTransport, error) {
-	chats, err := newFiltersManager(db, shh, privateKey, logger)
+	filtersManager, err := newFiltersManager(db, shh, privateKey, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +99,8 @@ func NewWhisperServiceTransport(
 		envelopesMonitor = NewEnvelopesMonitor(shh, envelopesMonitorConfig)
 		envelopesMonitor.Start()
 	}
-	return &WhisperServiceTransport{
+
+	t := &WhisperServiceTransport{
 		shh:              shh,
 		shhAPI:           whisper.NewPublicWhisperAPI(shh),
 		envelopesMonitor: envelopesMonitor,
@@ -97,52 +110,64 @@ func NewWhisperServiceTransport(
 			privateKey:        privateKey,
 			passToSymKeyCache: make(map[string]string),
 		},
-		chats:       chats,
+		filters:     filtersManager,
 		mailservers: mailservers,
 		logger:      logger.With(zap.Namespace("WhisperServiceTransport")),
-	}, nil
+	}
+
+	for _, opt := range opts {
+		if err := opt(t); err != nil {
+			return nil, err
+		}
+	}
+
+	return t, nil
+}
+
+func (a *WhisperServiceTransport) InitFilters(chatIDs []string, publicKeys []*ecdsa.PublicKey) ([]*Filter, error) {
+	return a.filters.Init(chatIDs, publicKeys, a.genericDiscoveryTopicEnabled)
 }
 
 // DEPRECATED
-func (a *WhisperServiceTransport) LoadFilters(chats []*Filter, genericDiscoveryTopicEnabled bool) ([]*Filter, error) {
-	return a.chats.InitWithChats(chats, genericDiscoveryTopicEnabled)
+func (a *WhisperServiceTransport) LoadFilters(filters []*Filter) ([]*Filter, error) {
+	return a.filters.InitWithFilters(filters, a.genericDiscoveryTopicEnabled)
 }
 
 // DEPRECATED
-func (a *WhisperServiceTransport) RemoveFilters(chats []*Filter) error {
-	return a.chats.Remove(chats...)
+func (a *WhisperServiceTransport) RemoveFilters(filters []*Filter) error {
+	return a.filters.Remove(filters...)
 }
 
 func (a *WhisperServiceTransport) Reset() error {
-	return a.chats.Reset()
+	return a.filters.Reset()
 }
 
 func (a *WhisperServiceTransport) ProcessNegotiatedSecret(secret NegotiatedSecret) error {
-	_, err := a.chats.LoadNegotiated(secret)
+	_, err := a.filters.LoadNegotiated(secret)
 	return err
 }
 
 func (a *WhisperServiceTransport) JoinPublic(chatID string) error {
-	_, err := a.chats.LoadPublic(chatID)
+	_, err := a.filters.LoadPublic(chatID)
 	return err
 }
 
 func (a *WhisperServiceTransport) LeavePublic(chatID string) error {
-	chat := a.chats.ChatByID(chatID)
+	chat := a.filters.Filter(chatID)
 	if chat != nil {
 		return nil
 	}
-	return a.chats.Remove(chat)
+	return a.filters.Remove(chat)
 }
 
 func (a *WhisperServiceTransport) JoinPrivate(publicKey *ecdsa.PublicKey) error {
-	_, err := a.chats.LoadContactCode(publicKey)
+	_, err := a.filters.LoadContactCode(publicKey)
 	return err
 }
 
 func (a *WhisperServiceTransport) LeavePrivate(publicKey *ecdsa.PublicKey) error {
-	chats := a.chats.ChatsByPublicKey(publicKey)
-	return a.chats.Remove(chats...)
+	filters := a.filters.FiltersByPublicKey(publicKey)
+	return a.filters.Remove(filters...)
 }
 
 type ChatMessages struct {
@@ -154,15 +179,15 @@ type ChatMessages struct {
 func (a *WhisperServiceTransport) RetrieveAllMessages() ([]ChatMessages, error) {
 	chatMessages := make(map[string]ChatMessages)
 
-	for _, chat := range a.chats.Chats() {
-		f := a.shh.GetFilter(chat.FilterID)
+	for _, filter := range a.filters.Filters() {
+		f := a.shh.GetFilter(filter.FilterID)
 		if f == nil {
 			return nil, errors.New("failed to return a filter")
 		}
 
-		messages := chatMessages[chat.ChatID]
-		messages.ChatID = chat.ChatID
-		messages.Public = chat.IsPublic()
+		messages := chatMessages[filter.ChatID]
+		messages.ChatID = filter.ChatID
+		messages.Public = filter.IsPublic()
 		messages.Messages = append(messages.Messages, f.Retrieve()...)
 	}
 
@@ -174,12 +199,12 @@ func (a *WhisperServiceTransport) RetrieveAllMessages() ([]ChatMessages, error) 
 }
 
 func (a *WhisperServiceTransport) RetrievePublicMessages(chatID string) ([]*whisper.ReceivedMessage, error) {
-	chat, err := a.chats.LoadPublic(chatID)
+	filter, err := a.filters.LoadPublic(chatID)
 	if err != nil {
 		return nil, err
 	}
 
-	f := a.shh.GetFilter(chat.FilterID)
+	f := a.shh.GetFilter(filter.FilterID)
 	if f == nil {
 		return nil, errors.New("failed to return a filter")
 	}
@@ -188,8 +213,8 @@ func (a *WhisperServiceTransport) RetrievePublicMessages(chatID string) ([]*whis
 }
 
 func (a *WhisperServiceTransport) RetrievePrivateMessages(publicKey *ecdsa.PublicKey) ([]*whisper.ReceivedMessage, error) {
-	chats := a.chats.ChatsByPublicKey(publicKey)
-	discoveryChats, err := a.chats.Init(nil, nil, true)
+	chats := a.filters.FiltersByPublicKey(publicKey)
+	discoveryChats, err := a.filters.Init(nil, nil, true)
 	if err != nil {
 		return nil, err
 	}
@@ -212,14 +237,14 @@ func (a *WhisperServiceTransport) RetrievePrivateMessages(publicKey *ecdsa.Publi
 func (a *WhisperServiceTransport) RetrieveRawAll() (map[Filter][]*whisper.ReceivedMessage, error) {
 	result := make(map[Filter][]*whisper.ReceivedMessage)
 
-	allChats := a.chats.Chats()
-	for _, chat := range allChats {
-		f := a.shh.GetFilter(chat.FilterID)
+	allFilters := a.filters.Filters()
+	for _, filter := range allFilters {
+		f := a.shh.GetFilter(filter.FilterID)
 		if f == nil {
 			return nil, errors.New("failed to return a filter")
 		}
 
-		result[*chat] = append(result[*chat], f.Retrieve()...)
+		result[*filter] = append(result[*filter], f.Retrieve()...)
 	}
 
 	return result, nil
@@ -242,13 +267,13 @@ func (a *WhisperServiceTransport) SendPublic(ctx context.Context, newMessage *wh
 		return nil, err
 	}
 
-	chat, err := a.chats.LoadPublic(chatName)
+	filter, err := a.filters.LoadPublic(chatName)
 	if err != nil {
 		return nil, err
 	}
 
-	newMessage.SymKeyID = chat.SymKeyID
-	newMessage.Topic = chat.Topic
+	newMessage.SymKeyID = filter.SymKeyID
+	newMessage.Topic = filter.Topic
 
 	return a.shhAPI.Post(ctx, *newMessage)
 }
@@ -258,7 +283,7 @@ func (a *WhisperServiceTransport) SendPrivateWithSharedSecret(ctx context.Contex
 		return nil, err
 	}
 
-	chat, err := a.chats.LoadNegotiated(NegotiatedSecret{
+	filter, err := a.filters.LoadNegotiated(NegotiatedSecret{
 		PublicKey: publicKey,
 		Key:       secret,
 	})
@@ -266,8 +291,8 @@ func (a *WhisperServiceTransport) SendPrivateWithSharedSecret(ctx context.Contex
 		return nil, err
 	}
 
-	newMessage.SymKeyID = chat.SymKeyID
-	newMessage.Topic = chat.Topic
+	newMessage.SymKeyID = filter.SymKeyID
+	newMessage.Topic = filter.Topic
 	newMessage.PublicKey = nil
 
 	return a.shhAPI.Post(ctx, *newMessage)
@@ -278,12 +303,12 @@ func (a *WhisperServiceTransport) SendPrivateWithPartitioned(ctx context.Context
 		return nil, err
 	}
 
-	chat, err := a.chats.LoadPartitioned(publicKey)
+	filter, err := a.filters.LoadPartitioned(publicKey)
 	if err != nil {
 		return nil, err
 	}
 
-	newMessage.Topic = chat.Topic
+	newMessage.Topic = filter.Topic
 	newMessage.PublicKey = crypto.FromECDSAPub(publicKey)
 
 	return a.shhAPI.Post(ctx, *newMessage)


### PR DESCRIPTION
This change adds `Messenger.Init()` method which based on the stored chats and contacts initializes Whisper filters.

It also contains some changes cleaning up term `filter` and `chat`.

Todo:
- [ ] add unit tests for `Messenger.Init()`