### PR TITLE
Enable parsing of messages

### DIFF
--- a/message_processor_test.go
+++ b/message_processor_test.go
@@ -128,6 +128,7 @@ func (s *MessageProcessorSuite) TestHandleDecodedMessagesSingle() {
 	s.Require().Equal(&privateKey.PublicKey, decodedMessages[0].SigPubKey())
 	s.Require().Equal(protocol.MessageID(&privateKey.PublicKey, encodedPayload), decodedMessages[0].ID)
 	s.Require().Equal(s.testMessage, decodedMessages[0].ParsedMessage)
+	s.Require().Equal(protocol.MessageT, decodedMessages[0].MessageType)
 }
 
 func (s *MessageProcessorSuite) TestHandleDecodedMessagesRaw() {
@@ -176,6 +177,7 @@ func (s *MessageProcessorSuite) TestHandleDecodedMessagesWrapped() {
 	s.Require().Equal(protocol.MessageID(&authorKey.PublicKey, wrappedPayload), decodedMessages[0].ID)
 	s.Require().Equal(encodedPayload, decodedMessages[0].DecryptedPayload)
 	s.Require().Equal(s.testMessage, decodedMessages[0].ParsedMessage)
+	s.Require().Equal(protocol.MessageT, decodedMessages[0].MessageType)
 }
 
 func (s *MessageProcessorSuite) TestHandleDecodedMessagesDatasync() {
@@ -212,11 +214,13 @@ func (s *MessageProcessorSuite) TestHandleDecodedMessagesDatasync() {
 	s.Require().Equal(protocol.MessageID(&relayerKey.PublicKey, encodedPayload), decodedMessages[0].ID)
 	s.Require().Equal(encodedPayload, decodedMessages[0].DecryptedPayload)
 	s.Require().Equal(s.testMessage, decodedMessages[0].ParsedMessage)
+	s.Require().Equal(protocol.MessageT, decodedMessages[0].MessageType)
 
 	s.Require().Equal(&authorKey.PublicKey, decodedMessages[1].SigPubKey())
 	s.Require().Equal(protocol.MessageID(&authorKey.PublicKey, wrappedPayload), decodedMessages[1].ID)
 	s.Require().Equal(encodedPayload, decodedMessages[1].DecryptedPayload)
 	s.Require().Equal(s.testMessage, decodedMessages[1].ParsedMessage)
+	s.Require().Equal(protocol.MessageT, decodedMessages[1].MessageType)
 }
 
 func (s *MessageProcessorSuite) TestHandleDecodedMessagesDatasyncEncrypted() {
@@ -277,9 +281,11 @@ func (s *MessageProcessorSuite) TestHandleDecodedMessagesDatasyncEncrypted() {
 	s.Require().Equal(protocol.MessageID(&relayerKey.PublicKey, encodedPayload), decodedMessages[0].ID)
 	s.Require().Equal(encodedPayload, decodedMessages[0].DecryptedPayload)
 	s.Require().Equal(s.testMessage, decodedMessages[0].ParsedMessage)
+	s.Require().Equal(protocol.MessageT, decodedMessages[0].MessageType)
 
 	s.Require().Equal(&authorKey.PublicKey, decodedMessages[1].SigPubKey())
 	s.Require().Equal(protocol.MessageID(&authorKey.PublicKey, wrappedPayload), decodedMessages[1].ID)
 	s.Require().Equal(encodedPayload, decodedMessages[1].DecryptedPayload)
 	s.Require().Equal(s.testMessage, decodedMessages[1].ParsedMessage)
+	s.Require().Equal(protocol.MessageT, decodedMessages[1].MessageType)
 }

--- a/messenger.go
+++ b/messenger.go
@@ -805,7 +805,7 @@ func (m *Messenger) RetrieveRawAll() (map[transport.Filter][]*protocol.StatusMes
 	for chat, messages := range chatWithMessages {
 		for _, shhMessage := range messages {
 			// TODO: fix this to use an exported method.
-			statusMessages, err := m.processor.handleMessages(shhMessage, false)
+			statusMessages, err := m.processor.handleMessages(shhMessage, true)
 			if err != nil {
 				logger.Info("failed to decode messages", zap.Error(err))
 				continue

--- a/v1/decoder.go
+++ b/v1/decoder.go
@@ -76,6 +76,8 @@ func statusMessageHandler(d transit.Decoder, value interface{}) (interface{}, er
 				switch keyKeyword {
 				case transit.Keyword("text"):
 					sm.Content.Text, ok = contentVal.(string)
+				case transit.Keyword("response-to"):
+					sm.Content.ResponseTo, ok = contentVal.(string)
 				case transit.Keyword("chat-id"):
 					sm.Content.ChatID, ok = contentVal.(string)
 				}

--- a/v1/message.go
+++ b/v1/message.go
@@ -34,8 +34,9 @@ var (
 
 // Content contains the chat ID and the actual text of a message.
 type Content struct {
-	ChatID string `json:"chat_id"`
-	Text   string `json:"text"`
+	ChatID     string `json:"chat_id"`
+	Text       string `json:"text"`
+	ResponseTo string `json:"response-to"`
 }
 
 // TimestampInMs is a timestamp in milliseconds.

--- a/v1/message_test.go
+++ b/v1/message_test.go
@@ -10,14 +10,14 @@ import (
 )
 
 var (
-	testMessageBytes  = []byte(`["~#c4",["abc123","text/plain","~:public-group-user-message",154593077368201,1545930773682,["^ ","~:chat-id","testing-adamb","~:text","abc123"]]]`)
+	testMessageBytes  = []byte(`["~#c4",["abc123","text/plain","~:public-group-user-message",154593077368201,1545930773682,["^ ","~:chat-id","testing-adamb","~:response-to", "id","~:text","abc123"]]]`)
 	testMessageStruct = Message{
 		Text:      "abc123",
 		ContentT:  "text/plain",
 		MessageT:  "public-group-user-message",
 		Clock:     154593077368201,
 		Timestamp: 1545930773682,
-		Content:   Content{"testing-adamb", "abc123"},
+		Content:   Content{"testing-adamb", "abc123", "id"},
 	}
 )
 


### PR DESCRIPTION
This commit enables parsing of messages in status-protocol-go, status-react will conditionally use that if the message type is supported and present.