### PR TITLE
Add name to content

### DIFF
--- a/v1/decoder.go
+++ b/v1/decoder.go
@@ -78,6 +78,8 @@ func statusMessageHandler(d transit.Decoder, value interface{}) (interface{}, er
 					sm.Content.Text, ok = contentVal.(string)
 				case transit.Keyword("response-to"):
 					sm.Content.ResponseTo, ok = contentVal.(string)
+				case transit.Keyword("name"):
+					sm.Content.Name, ok = contentVal.(string)
 				case transit.Keyword("chat-id"):
 					sm.Content.ChatID, ok = contentVal.(string)
 				}

--- a/v1/message.go
+++ b/v1/message.go
@@ -37,6 +37,7 @@ type Content struct {
 	ChatID     string `json:"chat_id"`
 	Text       string `json:"text"`
 	ResponseTo string `json:"response-to"`
+	Name       string `json:"name"` // the ENS name of the sender
 }
 
 // TimestampInMs is a timestamp in milliseconds.

--- a/v1/message_test.go
+++ b/v1/message_test.go
@@ -10,14 +10,14 @@ import (
 )
 
 var (
-	testMessageBytes  = []byte(`["~#c4",["abc123","text/plain","~:public-group-user-message",154593077368201,1545930773682,["^ ","~:chat-id","testing-adamb","~:response-to", "id","~:text","abc123"]]]`)
+	testMessageBytes  = []byte(`["~#c4",["abc123","text/plain","~:public-group-user-message",154593077368201,1545930773682,["^ ","~:chat-id","testing-adamb","~:name", "test-name","~:response-to", "id","~:text","abc123"]]]`)
 	testMessageStruct = Message{
 		Text:      "abc123",
 		ContentT:  "text/plain",
 		MessageT:  "public-group-user-message",
 		Clock:     154593077368201,
 		Timestamp: 1545930773682,
-		Content:   Content{"testing-adamb", "abc123", "id"},
+		Content:   Content{"testing-adamb", "abc123", "id", "test-name"},
 	}
 )
 


### PR DESCRIPTION
Sometimes messages have a `name` field in the `content` map.
This is used for the ENS name.
This commit adds the parsing of that field.